### PR TITLE
Dockerfile: Specify syntax version we are using

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # If you change the default source image, update the README, which references
 # the underlying Debian version.
 ARG DEBIAN_VERSION=bookworm


### PR DESCRIPTION
This way older versions of docker buildkit can use heredocs

You need to pair this with:

    DOCKER_BUILDKIT=1 docker build Debian/

or put this in /etc/docker/daemon.json and restart docker:

    {
        "features": {
            "buildkit": true
        }
    }

... with /etc/init.d/docker restart